### PR TITLE
docs(wrappers): clarify options lifecycle and clean demo index markup

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ table.use(bootstrapThemePlugin());
 
 Vanilla Tables is framework-agnostic. Use these minimal wrappers to integrate with your preferred stack.
 
+Wrapper behavior note:
+These minimal wrappers treat `options` as initialization-time configuration.
+If `options` can change at runtime in your app, re-create the table instance when `options` change.
+
 ### React
 
 ```jsx
@@ -187,7 +191,7 @@ export class VanillaTableComponent implements AfterViewInit, OnChanges, OnDestro
 
 ### Troubleshooting Notes
 
-- **React Strict Mode**: In development, React 18+ may mount components twice. The `instanceRef` check in `useEffect` prevents double initialization.
+- **React Strict Mode**: In development, React 18+ intentionally mounts, unmounts, and remounts components once to detect side effects. The cleanup in each wrapper keeps this behavior safe.
 - **Style Imports**: Ensure you import `vanilla-tables/styles` globally or within the component to apply base table styling.
 - **SSR**: Vanilla Tables requires a DOM environment. If using Next.js or Nuxt, wrap the component in a client-only check or use dynamic imports.
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -18,7 +18,7 @@
       <li><a href="./bulma.html">Bulma</a></li>
       <li><a href="./mui.html">MUI-like</a></li>
       <li><a href="./tailwind.html">Tailwind</a></li>
-      <hr />
+      <li class="list-unstyled mt-2 mb-2" aria-hidden="true"><hr class="my-2" /></li>
       <li><a href="./react-wrapper.html">React Wrapper</a></li>
       <li><a href="./vue-wrapper.html">Vue Wrapper</a></li>
     </ul>


### PR DESCRIPTION
Friendly follow-up after #4 to keep wrapper docs accurate and demo HTML valid.

Changes:
- Clarifies that wrapper `options` are init-time in minimal recipes
- Corrects React Strict Mode note wording
- Replaces invalid `<hr>` inside `<ul>` with valid list markup in demo index

Validation:
- npm run build
- npm test