### PR TITLE
docs(community): contributor funnel, discussions, and benchmark docs

### DIFF
--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -4,7 +4,12 @@
 
 Use GitHub Discussions or open a GitHub issue for usage questions:
 
+- https://github.com/lhozdroid/vanilla-tables/discussions
 - https://github.com/lhozdroid/vanilla-tables/issues
+
+For contribution-ready tasks, start here:
+
+- https://github.com/lhozdroid/vanilla-tables/issues/14
 
 ## Bug Reports
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Fast, framework-agnostic data tables in pure JavaScript.
 [![CI](https://github.com/lhozdroid/vanilla-tables/actions/workflows/ci.yml/badge.svg)](https://github.com/lhozdroid/vanilla-tables/actions/workflows/ci.yml)
 [![npm version](https://img.shields.io/npm/v/vanilla-tables.svg)](https://www.npmjs.com/package/vanilla-tables)
 [![npm downloads](https://img.shields.io/npm/dm/vanilla-tables.svg)](https://www.npmjs.com/package/vanilla-tables)
+[![GitHub Discussions](https://img.shields.io/github/discussions/lhozdroid/vanilla-tables)](https://github.com/lhozdroid/vanilla-tables/discussions)
 
 Vanilla Tables is an object-oriented table engine designed for real apps: rich features, extensible API, production-safe behavior, and strong test coverage.
 
@@ -220,6 +221,19 @@ export class VanillaTableComponent implements AfterViewInit, OnChanges, OnDestro
 - Stress + e2e + unit coverage pipeline.
 - Release verification script for dist artifacts, exports, size budgets, and tarball contents.
 
+### Baseline Snapshot (2026-02-19)
+
+Measured via `npm run bench` on local maintainer hardware using current defaults.
+
+| rows | render (ms) | refresh-hit (ms) | search (ms) | sort (ms) | status |
+| --- | --- | --- | --- | --- | --- |
+| 10000 | 14 | 3 | 16 | 6 | OK |
+| 25000 | 47 | 3 | 40 | 7 | OK |
+| 50000 | 59 | 2 | 47 | 12 | OK |
+| 100000 | 104 | 2 | 77 | 15 | STOP (render > 100ms target) |
+
+Methodology and reproduction commands: `docs/benchmark-methodology.md`
+
 ## Theming
 
 Default output is semantic and framework-neutral (`vt-*`).
@@ -277,7 +291,7 @@ Examples:
 ## Demos
 
 - Index: `demo/index.html`
-- Individual pages: vanilla, bootstrap, bulma, mui-like, tailwind
+- Individual pages: vanilla, bootstrap, bulma, mui-like, tailwind, react-wrapper, vue-wrapper
 
 Run locally:
 
@@ -349,6 +363,22 @@ PRs are welcome. Keep changes test-backed and consistent with project principles
 - performance-focused data paths
 - graceful degradation behavior
 - documented internals and public usage
+
+Start here:
+
+- Pick a task from pinned issue `#14`: https://github.com/lhozdroid/vanilla-tables/issues/14
+- Join roadmap discussion `#15`: https://github.com/lhozdroid/vanilla-tables/discussions/15
+- For questions: https://github.com/lhozdroid/vanilla-tables/discussions
+
+## Hall Of Contributors
+
+- [@Chidwan3578](https://github.com/Chidwan3578) - framework wrapper recipes and demos
+
+## Docs
+
+- Architecture: `docs/architecture.md`
+- Development workflow: `docs/development.md`
+- Benchmark methodology: `docs/benchmark-methodology.md`
 
 ## Project Health
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,37 @@
+# Architecture
+
+`vanilla-tables` keeps core concerns separated for predictable behavior and easier extension.
+
+## Core Modules
+
+- `src/core/state-store.js` (`StateStore`): Handles state mutations and row projection.
+- `src/core/renderer.js` (`Renderer`): Coordinates DOM renderer parts only.
+- `src/core/vanilla-table.js` (`VanillaTable`): Orchestrates lifecycle, events, plugins, and public API.
+
+## Data Flow
+
+1. `VanillaTable` receives rows + options and initializes `StateStore`, `Renderer`, and data source.
+2. User actions/events mutate store state through explicit methods.
+3. `refresh()` requests a projected view from the active data source.
+4. `Renderer` writes the current header/body/footer DOM from that view.
+5. Lifecycle and state events are emitted for integrations/plugins.
+
+## Data Sources
+
+- Client mode: `src/core/data-sources/client-data-source.js`
+- Server mode: `src/core/data-sources/server-data-source.js`
+- Resolver: `src/core/data-sources/create-data-source.js`
+
+## Parallel Projection
+
+- Worker pool: `src/core/parallel/projection-worker-pool.js`
+- Enabled through `options.parallel`
+- Falls back to sync path if workers are unavailable or fail
+
+## Extension Points
+
+- Plugins: `table.use(plugin)`
+- Hooks: `table.registerHook(name, callback)`
+- Theme plugins: `src/plugins/*`
+- Server adapters: `src/adapters/server-adapters.js`
+

--- a/docs/benchmark-methodology.md
+++ b/docs/benchmark-methodology.md
@@ -1,0 +1,35 @@
+# Benchmark Methodology
+
+## Purpose
+
+Provides reproducible baseline numbers for render, refresh-hit, search, and sort operations.
+
+## Commands
+
+```bash
+npm run bench
+npm run bench:memory
+```
+
+## Stress Benchmark Notes
+
+- Script: `benchmarks/table-benchmark.mjs`
+- Default thresholds: render <= 100ms, refresh-hit <= 100ms, search <= 100ms, sort <= 100ms
+- Default sampling: warmup-runs=1, repeat-runs=1 (median)
+- Default endpoint: `http://127.0.0.1:4173`
+
+## Memory Benchmark Notes
+
+- Script: `benchmarks/memory-cycle-benchmark.mjs`
+- Reports heap usage across repeated mount/update/destroy cycles
+
+## Repro Guidance
+
+- Run on an idle machine when possible.
+- Close other heavy browser tabs/processes.
+- Capture environment metadata when posting results:
+  - OS and version
+  - CPU model
+  - Node version
+  - Browser (for e2e perf scenarios)
+

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,49 @@
+# Development
+
+## Local Setup
+
+```bash
+npm install
+```
+
+## Build And Test
+
+```bash
+npm run build
+npm test
+```
+
+Optional:
+
+```bash
+npm run test:e2e
+npm run test:e2e:perf
+npm run bench
+npm run bench:memory
+```
+
+## Release Verification
+
+Before publish:
+
+```bash
+npm run build
+npm run test
+npm run test:e2e:perf
+npm run release:verify
+```
+
+## Contribution Workflow
+
+1. Pick an issue (start at `#14`): https://github.com/lhozdroid/vanilla-tables/issues/14
+2. Create a branch from `main`.
+3. Implement focused changes with tests/docs as needed.
+4. Run build + tests locally.
+5. Open a PR and include `Fixes #<issue-number>` when applicable.
+
+## Project Boundaries
+
+- Keep core framework-independent and dependency-light.
+- Add behavior through options, hooks, or plugins.
+- Preserve public API compatibility unless planning a major version change.
+


### PR DESCRIPTION
This PR implements immediate contributor-growth improvements requested after launch.

Included:
- README contributor funnel with pinned issue #14 and roadmap discussion #15
- Hall of Contributors section (initial recognition)
- GitHub Discussions badge and links
- Baseline benchmark snapshot + reproducibility link
- New docs pages: architecture, development workflow, benchmark methodology
- SUPPORT doc update with Discussions and start-here link

Validation:
- npm run build
- npm test